### PR TITLE
Fix Dockerfile to build a docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY . /go/src/github.com/kellegous/go
 RUN apk update \
   && apk add go git musl-dev \
   && go get github.com/kellegous/go \
-  && apk del go git \
+  && apk del go git musl-dev \
   && rm -rf /var/cache/apk/* \
   && rm -rf /go/src /go/pkg \
   && mkdir /data

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine
 ENV GOPATH /go
 COPY . /go/src/github.com/kellegous/go
 RUN apk update \
-  && apk add go git \
+  && apk add go git musl-dev \
   && go get github.com/kellegous/go \
   && apk del go git \
   && rm -rf /var/cache/apk/* \


### PR DESCRIPTION
For successfully building docker image.

If we doesn't add musl-dev, it will not compile since go can't find all C header files.