### PR TITLE
Parse remainder of URL.

### DIFF
--- a/web/admin.go
+++ b/web/admin.go
@@ -11,7 +11,7 @@ type adminHandler struct {
 }
 
 func adminGet(ctx *context.Context, w http.ResponseWriter, r *http.Request) {
-	p := parseName("/admin/", r.URL.Path)
+	p, _ := parseName("/admin/", r.URL.Path)
 
 	if p == "" {
 		writeJSONOk(w)


### PR DESCRIPTION
This patch will parse the remainder of the shortcut URL after the first slash (i.e., the path and parameters) and append it to the final URL.

For example, if http://go/issues redirects to http://github.com/kellegous/go/issues/, then http://go/issues/5 will now redirect to http://github.com/kellegous/go/issues/5. (The current behavior is to ignore the "5".)