### PR TITLE
Allow path after a shortcut: go/short/foobar

### DIFF
--- a/web/admin.go
+++ b/web/admin.go
@@ -11,7 +11,7 @@ type adminHandler struct {
 }
 
 func adminGet(ctx *context.Context, w http.ResponseWriter, r *http.Request) {
-	p := parseName("/admin/", r.URL.Path)
+	p, _ := parseName("/admin/", r.URL.Path)
 
 	if p == "" {
 		writeJSONOk(w)

--- a/web/name.go
+++ b/web/name.go
@@ -17,13 +17,13 @@ var bannedNames = map[string]bool{
 
 // Parse the shortcut name from the given URL path, given the base URL that is
 // handling the request.
-func parseName(base, path string) string {
+func parseName(base, path string) (string, string) {
 	t := path[len(base):]
 	ix := strings.Index(t, "/")
 	if ix == -1 {
-		return t
+		return t, ""
 	}
-	return t[:ix]
+	return t[:ix], t[ix:]
 }
 
 // Clean a shortcut name. Currently this just means stripping any leading

--- a/web/web.go
+++ b/web/web.go
@@ -41,7 +41,7 @@ func templateFromAssetFn(fn func() (*asset, error)) (*template.Template, error) 
 // The default handler responds to most requests. It is responsible for the
 // shortcut redirects and for sending unmapped shortcuts to the edit page.
 func getDefault(ctx *context.Context, w http.ResponseWriter, r *http.Request) {
-	p := parseName("/", r.URL.Path)
+	p, s := parseName("/", r.URL.Path)
 	if p == "" {
 		http.Redirect(w, r, "/edit/", http.StatusTemporaryRedirect)
 		return
@@ -58,7 +58,7 @@ func getDefault(ctx *context.Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	http.Redirect(w, r,
-		rt.URL,
+		rt.URL+s,
 		http.StatusTemporaryRedirect)
 
 }
@@ -94,7 +94,7 @@ func ListenAndServe(addr string, admin bool, version string, ctx *context.Contex
 		getDefault(ctx, w, r)
 	})
 	mux.HandleFunc("/edit/", func(w http.ResponseWriter, r *http.Request) {
-		p := parseName("/edit/", r.URL.Path)
+		p, _ := parseName("/edit/", r.URL.Path)
 
 		// if this is a banned name, just redirect to the local URI. That'll show em.
 		if isBannedName(p) {


### PR DESCRIPTION
This allows adding additional path to a shortened URL. For example, if
go/short redirects to http://example.com, go/short/foobar will redirect
to http://example.com/foobar.

An example usage is to shorten Google Docs headings. go/mydoc can
redirect to a document. go/mydoc/#heading=h.asdfgh123456 can then
redirect to a specific heading in the doc.

This feature is supported in the original golinks at Google.

Next step: Create a chrome extension that links to the go/ server and
shortens a given link based on the shortcuts already registered